### PR TITLE
Store file header in files for later use.

### DIFF
--- a/src/zip.unpack.js
+++ b/src/zip.unpack.js
@@ -222,7 +222,7 @@ jz.zip.unpack = function(buffer){
     }
     
     localFileHeaders.forEach(function(header, i){
-        (header.filename.split('/').pop() ? files : folders).push(i);
+        (header.filename.split('/').pop() ? files : folders).push(header);
     });
     
     return new jz.zip.ZipArchiveReader(buffer, files, folders, localFileHeaders, centralDirHeaders);


### PR DESCRIPTION
Changed storing of file header instead of index so that filename can be retrieved via getFileNames
